### PR TITLE
Fixed Game not starting if widget is enabled

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -46,7 +46,7 @@ seq_num = 0
 frame_num = 0
 
 mon_select = 1
-folder = "apps/python/logger/captures2/" # set dir for saving images
+folder = "apps/python/logger/captures/" # set dir for saving images
 
 if os.path.exists(folder) == False:
     os.mkdir(folder)

--- a/logger.py
+++ b/logger.py
@@ -46,7 +46,10 @@ seq_num = 0
 frame_num = 0
 
 mon_select = 1
-folder = "apps/python/logger/captures/" # set dir for saving images
+folder = "apps/python/logger/captures2/" # set dir for saving images
+
+if os.path.exists(folder) == False:
+    os.mkdir(folder)
 
 def toggle(dummy, var):
     global recording, seq_num, frame_num, recButton


### PR DESCRIPTION
Fixed the issue when the game was not starting if enabled the logger app in Assetto Corsa > Settings > General. This game started if the widget was not enabled. Upon further inspection of the code, I observed that this was due to the fact that there was no captures folder, and neither a code line which created it. When I added the code to create the captures folder, this issue was fixed. 

Hope you agree to this fix. I'm also planning to build some sort of agent using imitation learning, and your code was very beneficial. 